### PR TITLE
feat(cli): add logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /docs/
 
 /test/dest*
+dfs.log
 
 /coverage/
 /kcov-*

--- a/src/assets.zig
+++ b/src/assets.zig
@@ -25,4 +25,4 @@ pub const help_prefix =
 
 pub const opt_usage = "{u}{u}{s}{s}{s}{f} <{s}>";
 pub const examples_header = "{s}EXAMPLE:\n";
-pub const separator = "\n\x1b[2m--- --- ---\x1b[0m\n\n";
+pub const separator = "\x1b[2m--- --- ---\x1b[0m\n";

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -161,7 +161,7 @@ pub const setup_cmd: CommandT = .{
         },
         .{
             .name = "purge",
-            .description = "Delete application data (meta, backups)",
+            .description = "Delete application data (meta, backups, logs)",
         },
     },
     .opts = &.{

--- a/src/config.zig
+++ b/src/config.zig
@@ -434,3 +434,5 @@ const Config = @This();
 const std = @import("std");
 const Cli = @import("cli.zig");
 const Util = @import("util.zig");
+
+const WARN = Util.Level.WARNING;

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,6 +1,7 @@
 pub const XdgDir = enum {
     Config,
     Data,
+    State,
     Home,
 };
 
@@ -12,6 +13,7 @@ pub const ConfigResult = union(enum) {
 repository: []const u8,
 source: []const u8,
 destination: []const u8,
+logging: bool,
 ignore_list: [][]const u8,
 
 pub fn new(
@@ -29,6 +31,7 @@ pub fn new(
         .repository = repository,
         .source = source,
         .destination = path,
+        .logging = false,
         .ignore_list = &[_][]u8{},
     };
 }
@@ -205,6 +208,7 @@ pub fn migrateConfig(
         .repository = if (old_config.repository) |v| v else "",
         .source = if (old_config.source) |v| v else "",
         .destination = if (old_config.destination) |v| v else "",
+        .logging = if (old_config.logging) |v| v else false,
         .ignore_list = ignore_list,
     };
 
@@ -285,6 +289,7 @@ pub fn getXdgDir(allocator: std.mem.Allocator, env_var: XdgDir) ![]const u8 {
         switch (env_var) {
             .Config => "XDG_CONFIG_HOME",
             .Data => "XDG_DATA_HOME",
+            .State => "XDG_STATE_HOME",
             .Home => "HOME",
         },
     ) catch {
@@ -302,6 +307,12 @@ pub fn getXdgDir(allocator: std.mem.Allocator, env_var: XdgDir) ![]const u8 {
                 "share",
                 "dfs",
             }),
+            .State => return try std.fs.path.join(allocator, &.{
+                home,
+                ".local",
+                "state",
+                "dfs",
+            }),
             .Home => return allocator.dupe(u8, home),
         }
     };
@@ -314,6 +325,7 @@ test migrateConfig {
         \\.{
         \\    .repository = "https://gibson.com/test",
         \\    .source = "test/root-back",
+        \\    .destination = "/tmp/test",
         \\    .ignore_list = .{"foo","bar"},
         \\}
         \\
@@ -323,7 +335,8 @@ test migrateConfig {
         \\.{
         \\    .repository = "https://gibson.com/test",
         \\    .source = "test/root-back",
-        \\    .destination = "",
+        \\    .destination = "/tmp/test",
+        \\    .logging = false,
         \\    .ignore_list = .{ "foo", "bar" },
         \\}
         \\

--- a/src/dotfile.zig
+++ b/src/dotfile.zig
@@ -206,7 +206,7 @@ pub fn lastMod(
 fn forwardSync(
     self: Dotfile,
     allocator: std.mem.Allocator,
-    stdout: anytype,
+    stdout: *std.Io.Writer,
     counter: *Util.Counter,
     template_content: []const u8,
     template_mode: usize,
@@ -219,20 +219,11 @@ fn forwardSync(
     const result = if (is_text) lib.applyTemplate(
         allocator,
         template_content,
-    ) catch {
+    ) catch |err| {
         counter.errors += 1;
         try self.recordLastSync(allocator);
 
-        if (!json and (dry_run or verbose)) {
-            try stdout.print("{s}{s}ERROR | {s}{s}\n", .{
-                Cli.red,
-                Cli.bold,
-                self.dest,
-                Cli.reset,
-            });
-        }
-
-        return;
+        return err;
     } else template_content;
 
     defer if (is_text) allocator.free(result);
@@ -324,7 +315,7 @@ fn forwardSync(
 fn backSync(
     self: Dotfile,
     allocator: std.mem.Allocator,
-    stdout: anytype,
+    stdout: *std.Io.Writer,
     counter: *Util.Counter,
     template_content: []const u8,
     template_mode: usize,
@@ -417,7 +408,7 @@ fn backSync(
 pub fn processFile(
     self: Dotfile,
     allocator: std.mem.Allocator,
-    stdout: anytype,
+    stdout: *std.Io.Writer,
     direction: Cli.Direction,
     counter: *Util.Counter,
     dry_run: bool,
@@ -517,14 +508,10 @@ pub fn processFile(
             allocator,
             input,
             null,
-            .{},
-        ) catch {
+            .{ .ignore_unknown_fields = true },
+        ) catch |err| {
             counter.errors += 1;
-
-            return std.debug.print(
-                "{s}{s}ERROR | Failed to parse ZON file:{s} {s}\n",
-                .{ Cli.red, Cli.bold, Cli.reset, meta_file_path },
-            );
+            return err;
         };
 
         defer std.zon.parse.free(allocator, meta);
@@ -593,7 +580,9 @@ pub fn processFile(
 
 test processFile {
     var counter = Util.Counter.new(false);
-    var buff = std.array_list.Managed(u8).init(std.testing.allocator);
+    var buf: [4096]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&buf);
+    const writer = &stdout_writer.interface;
 
     errdefer {
         std.fs.cwd().deleteTree("test/root2") catch unreachable;
@@ -603,11 +592,10 @@ test processFile {
     // dual
     {
         var dotfile_d = new("test/root/testfile1", "test/dest2/testfile-unit");
-        defer buff.deinit();
 
         _ = try dotfile_d.processFile(
             std.testing.allocator,
-            buff.writer(),
+            writer,
             Cli.Direction.dual,
             &counter,
             false,
@@ -643,7 +631,7 @@ test processFile {
 
         _ = try dotfile_f.processFile(
             std.testing.allocator,
-            buff.writer(),
+            writer,
             Cli.Direction.forward,
             &counter,
             false,
@@ -703,7 +691,7 @@ test processFile {
 
         _ = try dotfile_b.processFile(
             std.testing.allocator,
-            buff.writer(),
+            writer,
             Cli.Direction.back,
             &counter,
             false,
@@ -742,3 +730,5 @@ const Cli = @import("cli.zig");
 const Config = @import("config.zig");
 const Util = @import("util.zig");
 const assets = @import("assets.zig");
+
+const ERR = Util.Level.ERROR;

--- a/src/dotfile.zig
+++ b/src/dotfile.zig
@@ -288,7 +288,7 @@ fn forwardSync(
         if (dry_run) {
             if (is_text)
                 try stdout.print(
-                    "{s}{s}DATA | render:{s}\n\n{s}{s}",
+                    "{s}{s}DATA | render:\n\n{s}{s}\n{s}",
                     .{
                         Cli.yellow,
                         Cli.bold,
@@ -309,6 +309,8 @@ fn forwardSync(
                     },
                 );
         }
+
+        try stdout.flush();
     }
 }
 
@@ -392,7 +394,7 @@ fn backSync(
 
         if (dry_run) {
             try stdout.print(
-                "{s}{s}DATA | template:{s}\n\n{s}{s}",
+                "{s}{s}DATA | template:{s}{s}\n{s}",
                 .{
                     Cli.yellow,
                     Cli.bold,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,11 +1,3 @@
-pub const std_options: std.Options = .{
-    .logFn = Util.logToFile,
-    .log_level = switch (builtin.mode) {
-        .Debug => .debug,
-        else => .info,
-    },
-};
-
 pub const CommandT = Cli.CommandT;
 pub const setup_cmd = Cli.setup_cmd;
 
@@ -98,13 +90,11 @@ pub fn main() !void {
 
     var custom_config_path: ?[]const u8 = null;
     var usage_help_called = false;
+    var logging = false;
     var dry_run = false;
     var json = false;
     var args_iter = try cova.ArgIteratorGeneric.init(allocator);
     defer args_iter.deinit();
-
-    try Util.setLogPath(allocator);
-    defer allocator.free(Util.LOG_FILE);
 
     cova.parseArgs(
         &args_iter,
@@ -252,6 +242,7 @@ pub fn main() !void {
                 std.process.exit(1);
             };
 
+            Util.log(WARN, "Config updated!", .{});
             _ = try stderr.print(
                 "{s}Config updated{s}\n",
                 .{ Cli.green, Cli.reset },
@@ -265,6 +256,10 @@ pub fn main() !void {
     };
 
     defer std.zon.parse.free(allocator, config);
+
+    logging = config.logging;
+
+    if (logging) try Util.setLogger(allocator);
 
     if (opts.get("destination")) |dest| {
         config.destination = try dest.val.getAs([]const u8);
@@ -349,10 +344,26 @@ pub fn main() !void {
         files.deinit(allocator);
     }
 
-    var src_dir = try std.fs.cwd().openDir(
+    var src_dir = std.fs.cwd().openDir(
         source_with_slash,
         .{ .iterate = true },
-    );
+    ) catch {
+        if (logging) Util.log(
+            ERR,
+            "Source not found: {s}",
+            .{source_with_slash},
+        );
+
+        try stderr.print("{s}{s}ERROR | Not found:{s} {s}\n", .{
+            Cli.red,
+            Cli.bold,
+            Cli.reset,
+            source_with_slash,
+        });
+
+        try stderr.flush();
+        std.process.exit(1);
+    };
 
     defer src_dir.close();
 
@@ -381,8 +392,12 @@ pub fn main() !void {
 
         defer scan_node.end();
 
+        if (logging) Util.log(INFO, "Scanning the source", .{});
+
         walk: while (try walker.next()) |entry| {
             if (Util.isIgnored(entry.basename, ignore_items)) {
+                if (logging) Util.log(INFO, "Ignoring: {s}", .{entry.basename});
+
                 if (entry.kind == .directory) {
                     // remove from stack, with prejudice
                     var item = walker.stack.pop().?;
@@ -424,6 +439,8 @@ pub fn main() !void {
 
         defer validate_node.end();
 
+        if (logging) Util.log(INFO, "Validating", .{});
+
         for (files.items) |file| {
             _ = file.validate(
                 allocator,
@@ -449,8 +466,17 @@ pub fn main() !void {
         const direction_opt = sync_opts.get("direction").?;
         const direction = try direction_opt.val.getAs(Cli.Direction);
 
+        if (logging) Util.log(
+            INFO,
+            "Syncing ({s}/{s})",
+            .{ @tagName(direction), switch (dry_run) {
+                true => "dry",
+                false => "live",
+            } },
+        );
+
         for (files.items) |file| {
-            try file.processFile(
+            file.processFile(
                 allocator,
                 stdout,
                 direction,
@@ -458,7 +484,20 @@ pub fn main() !void {
                 dry_run,
                 verbose,
                 json,
-            );
+            ) catch |err| {
+                if (logging) Util.log(ERR, "{}: {s}", .{ err, file.src });
+                if (!json) {
+                    try stderr.print("{s}{s}ERROR | {}:{s} {s}\n", .{
+                        Cli.bold,
+                        Cli.red,
+                        err,
+                        Cli.reset,
+                        file.src,
+                    });
+
+                    try stderr.flush();
+                }
+            };
 
             try stdout.flush();
             sync_node.completeOne();
@@ -510,6 +549,19 @@ pub fn main() !void {
         }
     }
 
+    if (logging) Util.log(
+        INFO,
+        "Finished: total {d}, updated {d}, templates {d}, renders {d}, binaries {d}, errors {d}",
+        .{
+            counter.total,
+            counter.updated,
+            counter.template,
+            counter.render,
+            counter.binary,
+            counter.errors,
+        },
+    );
+
     if (!json and (sync_cmd or validate_cmd)) {
         try stdout.print("{s}{s}DONE{s}\n", .{
             Cli.bold,
@@ -534,3 +586,7 @@ const Dotfile = @import("dotfile.zig");
 const Util = @import("util.zig");
 const Cli = @import("cli.zig");
 const assets = @import("assets.zig");
+
+const INFO = Util.Level.INFO;
+const ERR = Util.Level.ERROR;
+const WARN = Util.Level.WARNING;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,3 +1,11 @@
+pub const std_options: std.Options = .{
+    .logFn = Util.logToFile,
+    .log_level = switch (builtin.mode) {
+        .Debug => .debug,
+        else => .info,
+    },
+};
+
 pub const CommandT = Cli.CommandT;
 pub const setup_cmd = Cli.setup_cmd;
 
@@ -94,6 +102,9 @@ pub fn main() !void {
     var json = false;
     var args_iter = try cova.ArgIteratorGeneric.init(allocator);
     defer args_iter.deinit();
+
+    try Util.setLogPath(allocator);
+    defer allocator.free(Util.LOG_FILE);
 
     cova.parseArgs(
         &args_iter,
@@ -515,6 +526,7 @@ test {
 }
 
 const std = @import("std");
+const builtin = @import("builtin");
 const build_options = @import("build_options");
 const cova = @import("cova");
 const Config = @import("config.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -66,9 +66,7 @@ fn init(
     try Util.cloneRepo(allocator, repo, src);
     try config.write(allocator, config_path);
     _ = try stdout.write("COMPLETED\n");
-
     try stdout.flush();
-    std.process.exit(0);
 }
 
 pub fn main() !void {
@@ -116,7 +114,7 @@ pub fn main() !void {
 
     if (usage_help_called) {
         try stdout.flush();
-        std.process.exit(0);
+        return;
     }
 
     if (main_cmd.checkFlag("version")) {
@@ -126,7 +124,7 @@ pub fn main() !void {
         );
 
         try stdout.flush();
-        std.process.exit(0);
+        return;
     }
 
     if (main_cmd.checkFlag("json")) {
@@ -164,13 +162,14 @@ pub fn main() !void {
         try std.fs.cwd().deleteTree(data);
         try stdout.print("COMPLETED\n", .{});
         try stdout.flush();
-        std.process.exit(0);
+
+        return;
     }
 
     if (main_cmd.checkSubCmd("init")) {
         try init(allocator, stdout, config_path);
         try stdout.flush();
-        std.process.exit(0);
+        return;
     } else if (main_cmd.matchSubCmd("bootstrap")) |bootstrap_cmd| {
         const bootstrap_opts = try bootstrap_cmd.getOpts(.{});
         const url = try bootstrap_opts.get("url").?.val.getAs([]const u8);
@@ -187,7 +186,8 @@ pub fn main() !void {
         });
 
         try stdout.flush();
-        std.process.exit(0);
+
+        return;
     }
 
     // no more early exits from this point
@@ -211,7 +211,7 @@ pub fn main() !void {
                 Cli.reset,
             });
 
-            Config.migrateConfig(allocator, config_path) catch {
+            Config.migrateConfig(allocator, config_path) catch |err| {
                 try stderr.print("{s}{s}INVALID CONFIG{s}: {s}\n", .{
                     Cli.red,
                     Cli.bold,
@@ -239,7 +239,7 @@ pub fn main() !void {
 
                 _ = try stderr.write("\n\nExiting...\n");
                 try stderr.flush();
-                std.process.exit(1);
+                return err;
             };
 
             Util.log(WARN, "Config updated!", .{});
@@ -324,7 +324,7 @@ pub fn main() !void {
             dry_run = dry_opt.val.isSet();
 
             if (!json and dry_run) {
-                try stdout.print("{s}{s}DRY RUN{s}\n\n", .{
+                try stdout.print("{s}{s}DRY RUN{s}\n", .{
                     Cli.italic,
                     Cli.blink,
                     Cli.reset,
@@ -344,29 +344,42 @@ pub fn main() !void {
         files.deinit(allocator);
     }
 
+    try stdout.print("\nSource is {s}{s}{s}\n", .{
+        Cli.underline,
+        source_with_slash,
+        Cli.reset,
+    });
+
+    try stdout.flush();
+
     var src_dir = std.fs.cwd().openDir(
         source_with_slash,
         .{ .iterate = true },
-    ) catch {
-        if (logging) Util.log(
-            ERR,
-            "Source not found: {s}",
-            .{source_with_slash},
-        );
+    ) catch |err| {
+        switch (err) {
+            error.FileNotFound => {
+                if (logging) Util.log(
+                    ERR,
+                    "Source not found: {s}",
+                    .{source_with_slash},
+                );
 
-        try stderr.print("{s}{s}ERROR | Not found:{s} {s}\n", .{
-            Cli.red,
-            Cli.bold,
-            Cli.reset,
-            source_with_slash,
-        });
-
-        try stderr.flush();
-        std.process.exit(1);
+                try stderr.flush();
+                return err;
+            },
+            else => return err,
+        }
     };
 
     defer src_dir.close();
 
+    try stdout.print("Destination is {s}{s}{s}\n", .{
+        Cli.underline,
+        dest_with_slash,
+        Cli.reset,
+    });
+
+    try stdout.flush();
     // progress
     const no_progress = (json or verbose or dry_run) and
         (!sync_cmd or !validate_cmd);
@@ -455,6 +468,7 @@ pub fn main() !void {
     }
 
     if (sync_cmd and !validate_cmd) {
+        if (!json and (verbose or dry_run)) _ = try stdout.write("\n");
         const sync_opts = try main_cmd.getSubCmd("sync").?.getOpts(.{});
         const sync_node = main_node.start(
             "Syncing",
@@ -511,7 +525,7 @@ pub fn main() !void {
         _ = try stdout.write("\n");
     } else {
         if (sync_cmd) {
-            try stdout.print("TOTAL: {s}{d}{s}\n", .{
+            try stdout.print("\nTOTAL: {s}{d}{s}\n", .{
                 Cli.underline,
                 counter.total,
                 Cli.reset,

--- a/src/main.zig
+++ b/src/main.zig
@@ -241,7 +241,7 @@ pub fn main() !void {
                     stderr,
                 );
 
-                _ = try stderr.write("\n\nExiting...\n");
+                _ = try stderr.write("\n\n");
                 try stderr.flush();
                 return err;
             };

--- a/src/main.zig
+++ b/src/main.zig
@@ -159,7 +159,11 @@ pub fn main() !void {
         const data = try Config.getXdgDir(allocator, Config.XdgDir.Data);
         defer allocator.free(data);
 
+        const state = try Config.getXdgDir(allocator, Config.XdgDir.State);
+        defer allocator.free(state);
+
         try std.fs.cwd().deleteTree(data);
+        try std.fs.cwd().deleteTree(state);
         try stdout.print("COMPLETED\n", .{});
         try stdout.flush();
 

--- a/src/util.zig
+++ b/src/util.zig
@@ -1,4 +1,11 @@
 pub var LOG_FILE: []const u8 = "dfs.log";
+var LOG_FILE_BUF: [std.fs.max_path_bytes]u8 = undefined;
+
+pub const Level = enum {
+    INFO,
+    ERROR,
+    WARNING,
+};
 
 pub const Counter = struct {
     total: usize,
@@ -147,35 +154,27 @@ pub fn isText(data: []const u8) bool {
     return (non_text_count * 100 / data.len) < 10;
 }
 
-pub fn setLogPath(allocator: std.mem.Allocator) !void {
+pub fn setLogger(allocator: std.mem.Allocator) !void {
     const state_dir = try Config.getXdgDir(allocator, Config.XdgDir.State);
     defer allocator.free(state_dir);
 
     try createDirRecursively(allocator, state_dir);
 
-    LOG_FILE = try std.fmt.allocPrint(
-        allocator,
+    LOG_FILE = try std.fmt.bufPrint(
+        &LOG_FILE_BUF,
         "{s}/dfs.log",
         .{state_dir},
     );
 }
 
-pub fn logToFile(
-    comptime level: std.log.Level,
-    comptime scope: @Type(.enum_literal),
-    comptime format: []const u8,
+pub fn log(
+    comptime level: Level,
+    comptime message: []const u8,
     args: anytype,
 ) void {
     var buf: [std.fs.max_path_bytes * 10]u8 = undefined;
-    const scope_prefix = "(" ++ switch (scope) {
-        .dfs, .cova, std.log.default_log_scope => @tagName(scope),
-        else => if (@intFromEnum(level) <= @intFromEnum(std.log.Level.err))
-            @tagName(scope)
-        else
-            return,
-    } ++ "): ";
 
-    const prefix = "[" ++ comptime level.asText() ++ "] " ++ scope_prefix;
+    const prefix = "[" ++ comptime @tagName(level) ++ "] ";
     const timestamp_ns = std.time.nanoTimestamp();
     const timestamp = @divFloor(timestamp_ns, std.time.ns_per_s);
     const nanos: u32 = @intCast(@mod(timestamp_ns, std.time.ns_per_s));
@@ -190,7 +189,7 @@ pub fn logToFile(
     const msg = std.fmt.bufPrint(
         &buf,
         "[{d:0>4}-{d:0>2}-{d:0>2} {d:0>2}:{d:0>2}:{d:0>2}.{d:0>9}] " ++
-            prefix ++ format ++ "\n",
+            prefix ++ message ++ "\n",
         .{
             year_day.year,
             month_day.month.numeric(),
@@ -202,30 +201,22 @@ pub fn logToFile(
         } ++ args,
     ) catch return;
 
-    if (@intFromEnum(level) == @intFromEnum(std.log.Level.err)) {
-        var stderr_buffer: [1024]u8 = undefined;
-        var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
-        const stderr = &stderr_writer.interface;
-        nosuspend stderr.writeAll(msg) catch return;
-        stderr.flush() catch return;
-    } else {
-        const file = std.fs.cwd().openFile(LOG_FILE, .{
-            .mode = .write_only,
-        }) catch |err| f: {
-            if (err == error.FileNotFound) {
-                break :f std.fs.cwd().createFile(
-                    LOG_FILE,
-                    .{ .mode = 0o600 },
-                ) catch return;
-            }
+    const file = std.fs.cwd().openFile(LOG_FILE, .{
+        .mode = .write_only,
+    }) catch |err| f: {
+        if (err == error.FileNotFound) {
+            break :f std.fs.cwd().createFile(
+                LOG_FILE,
+                .{ .mode = 0o600 },
+            ) catch return;
+        }
 
-            return;
-        };
+        return;
+    };
 
-        defer file.close();
-        file.seekFromEnd(0) catch return;
-        nosuspend file.writeAll(msg) catch return;
-    }
+    defer file.close();
+    file.seekFromEnd(0) catch return;
+    file.writeAll(msg) catch return;
 }
 
 const std = @import("std");

--- a/src/util.zig
+++ b/src/util.zig
@@ -219,6 +219,30 @@ pub fn log(
     file.writeAll(msg) catch return;
 }
 
+test log {
+    const allocator = std.testing.allocator;
+    const message = "Log test";
+    log(Level.INFO, message, .{});
+
+    const log_file = try std.fs.cwd().openFile("dfs.log", .{});
+    defer log_file.close();
+
+    const log_size: usize = @intCast((try log_file.stat()).size);
+    const log_content = try log_file.readToEndAlloc(
+        allocator,
+        log_size,
+    );
+
+    const expected = "] [INFO] Log test\n";
+
+    defer {
+        allocator.free(log_content);
+        std.fs.cwd().deleteFile("dfs.log") catch unreachable;
+    }
+
+    try std.testing.expectStringEndsWith(log_content, expected);
+}
+
 const std = @import("std");
 const builtin = @import("builtin");
 const main = @import("main.zig");

--- a/src/util.zig
+++ b/src/util.zig
@@ -1,3 +1,5 @@
+pub var LOG_FILE: []const u8 = "dfs.log";
+
 pub const Counter = struct {
     total: usize,
     updated: usize,
@@ -143,6 +145,87 @@ pub fn isText(data: []const u8) bool {
 
     // treat as binary if the threshold is reached
     return (non_text_count * 100 / data.len) < 10;
+}
+
+pub fn setLogPath(allocator: std.mem.Allocator) !void {
+    const state_dir = try Config.getXdgDir(allocator, Config.XdgDir.State);
+    defer allocator.free(state_dir);
+
+    try createDirRecursively(allocator, state_dir);
+
+    LOG_FILE = try std.fmt.allocPrint(
+        allocator,
+        "{s}/dfs.log",
+        .{state_dir},
+    );
+}
+
+pub fn logToFile(
+    comptime level: std.log.Level,
+    comptime scope: @Type(.enum_literal),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    var buf: [std.fs.max_path_bytes * 10]u8 = undefined;
+    const scope_prefix = "(" ++ switch (scope) {
+        .dfs, .cova, std.log.default_log_scope => @tagName(scope),
+        else => if (@intFromEnum(level) <= @intFromEnum(std.log.Level.err))
+            @tagName(scope)
+        else
+            return,
+    } ++ "): ";
+
+    const prefix = "[" ++ comptime level.asText() ++ "] " ++ scope_prefix;
+    const timestamp_ns = std.time.nanoTimestamp();
+    const timestamp = @divFloor(timestamp_ns, std.time.ns_per_s);
+    const nanos: u32 = @intCast(@mod(timestamp_ns, std.time.ns_per_s));
+    const epoch = std.time.epoch.EpochSeconds{
+        .secs = @intCast(timestamp),
+    };
+
+    const day = epoch.getEpochDay();
+    const day_seconds = epoch.getDaySeconds();
+    const year_day = day.calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+    const msg = std.fmt.bufPrint(
+        &buf,
+        "[{d:0>4}-{d:0>2}-{d:0>2} {d:0>2}:{d:0>2}:{d:0>2}.{d:0>9}] " ++
+            prefix ++ format ++ "\n",
+        .{
+            year_day.year,
+            month_day.month.numeric(),
+            month_day.day_index + 1,
+            day_seconds.getHoursIntoDay(),
+            day_seconds.getMinutesIntoHour(),
+            day_seconds.getSecondsIntoMinute(),
+            nanos,
+        } ++ args,
+    ) catch return;
+
+    if (@intFromEnum(level) == @intFromEnum(std.log.Level.err)) {
+        var stderr_buffer: [1024]u8 = undefined;
+        var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
+        const stderr = &stderr_writer.interface;
+        nosuspend stderr.writeAll(msg) catch return;
+        stderr.flush() catch return;
+    } else {
+        const file = std.fs.cwd().openFile(LOG_FILE, .{
+            .mode = .write_only,
+        }) catch |err| f: {
+            if (err == error.FileNotFound) {
+                break :f std.fs.cwd().createFile(
+                    LOG_FILE,
+                    .{ .mode = 0o600 },
+                ) catch return;
+            }
+
+            return;
+        };
+
+        defer file.close();
+        file.seekFromEnd(0) catch return;
+        nosuspend file.writeAll(msg) catch return;
+    }
 }
 
 const std = @import("std");

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -86,6 +86,10 @@ test "sync" {
         \\|___/ \_|   \____/
         \\
         \\SYNC STARTED
+        \\
+        \\Source is test/root/
+        \\Destination is test/dest/
+        \\
         \\TOTAL: 3
         \\UPDATED: 2
         \\TEMPLATES: 0
@@ -154,6 +158,9 @@ test "sync-dry" {
         \\
         \\SYNC STARTED
         \\DRY RUN
+        \\
+        \\Source is test/root-dry/
+        \\Destination is test/dest-dry/
         \\
         \\FILE | test/dest-dry/testfile1
         \\DATA | render:

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -445,6 +445,7 @@ test "config bad" {
         \\    .repository = "https://gibson.com/git/dotfiles",
         \\    .source = "$HOME/src/dotfiles",
         \\    .destination = "/tmp/test",
+        \\    .logging = false,
         \\    .ignore_list = .{},
         \\}
         \\

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -455,9 +455,6 @@ test "config bad" {
         \\    .logging = false,
         \\    .ignore_list = .{},
         \\}
-        \\
-        \\Exiting...
-        \\
     ;
 
     const out = try stripAnsi(allocator, proc.out);
@@ -468,7 +465,7 @@ test "config bad" {
         allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, expected_err);
+    try std.testing.expect(std.mem.indexOf(u8, proc.err, expected_err) != null);
     try std.testing.expectEqual(proc.term.Exited, 1);
 }
 

--- a/test/conf-back-forced.zon
+++ b/test/conf-back-forced.zon
@@ -2,5 +2,6 @@
     .repository = "",
     .source = "test/root-back-forced",
     .destination = "test/dest-back-forced",
+    .logging = false,
     .ignore_list = .{},
 }

--- a/test/conf-back.zon
+++ b/test/conf-back.zon
@@ -2,5 +2,6 @@
     .repository = "",
     .source = "test/root-back",
     .destination = "test/dest-back",
+    .logging = false,
     .ignore_list = .{},
 }

--- a/test/conf-dry.zon
+++ b/test/conf-dry.zon
@@ -2,5 +2,6 @@
     .repository = "",
     .source = "test/root-dry",
     .destination = "test/dest-dry",
+    .logging = false,
     .ignore_list = .{},
 }

--- a/test/conf-forward-forced.zon
+++ b/test/conf-forward-forced.zon
@@ -2,5 +2,6 @@
     .repository = "",
     .source = "test/root-forward-forced",
     .destination = "test/dest-forward-forced",
+    .logging = false,
     .ignore_list = .{},
 }

--- a/test/conf.zon
+++ b/test/conf.zon
@@ -2,5 +2,6 @@
     .repository = "",
     .source = "test/root",
     .destination = "test/dest",
+    .logging = false,
     .ignore_list = .{},
 }


### PR DESCRIPTION
This is a custom logger implementation; logging is off by default (via config).
Example `dfs.log`:
```
[2025-10-15 21:41:06.522047714] [INFO] Scanning the source
[2025-10-15 21:41:06.522203411] [INFO] Ignoring: README.md
[2025-10-15 21:41:06.522861165] [INFO] Ignoring: .git
[2025-10-15 21:41:06.522884557] [INFO] Ignoring: .gitignore
[2025-10-15 21:41:06.525839083] [INFO] Ignoring: .github
[2025-10-15 21:41:06.525862043] [INFO] Ignoring: .gitmodules
[2025-10-15 21:41:06.525911451] [INFO] Ignoring: .gitignore
[2025-10-15 21:41:06.525927694] [INFO] Ignoring: LICENSE
[2025-10-15 21:41:06.526006503] [INFO] Ignoring: .git
[2025-10-15 21:41:06.526088653] [INFO] Ignoring: CHANGELOG.md
[2025-10-15 21:41:06.527204616] [INFO] Ignoring: .github
[2025-10-15 21:41:06.527226348] [INFO] Ignoring: README.md
[2025-10-15 21:41:06.527351231] [INFO] Ignoring: .git
[2025-10-15 21:41:06.527531399] [INFO] Syncing (dual/live)
[2025-10-15 21:41:06.561288265] [ERROR] error.InvalidTemplateGroup: /home/charlie/test1/.zshrc
[2025-10-15 21:41:06.713702784] [ERROR] error.ParseZon: /home/charlie/test1/misc/puffy-red.png
[2025-10-15 21:41:06.716497318] [INFO] Finished: total 120, updated 0, templates 0, renders 107, binaries 12, errors 2
```

Fixes #65 